### PR TITLE
Fix(utils): Correctly parse numbers with multiple decimals

### DIFF
--- a/parseNumber.test.mjs
+++ b/parseNumber.test.mjs
@@ -9,3 +9,11 @@ test('parseNumber handles negative numbers', () => {
 test('parseNumber handles currency symbols', () => {
   assert.strictEqual(parseNumber('Rp12,345'), 12345);
 });
+
+test('parseNumber handles multiple decimal points', () => {
+  assert.strictEqual(parseNumber('1.2.3'), 1.2);
+});
+
+test('parseNumber handles misplaced hyphens', () => {
+  assert.strictEqual(parseNumber('5-5'), 5);
+});

--- a/utils.mjs
+++ b/utils.mjs
@@ -1,7 +1,17 @@
 export function parseNumber(v) {
   if (typeof v === "number") return v;
   if (!v) return 0;
-  const cleaned = String(v).replace(/[^0-9.-]/g, "");
-  const n = Number(cleaned);
+
+  // Remove commas, then find the number
+  const str = String(v).replace(/,/g, '');
+
+  // Match the first number-like pattern. This handles misplaced hyphens
+  // and multiple decimals by only matching the first valid occurrence.
+  const match = str.match(/-?\d+(\.\d+)?/);
+
+  if (!match) return 0;
+
+  const n = Number(match[0]);
+
   return isNaN(n) ? 0 : n;
 }


### PR DESCRIPTION
The parseNumber function was incorrectly handling strings with multiple decimal points or misplaced hyphens, causing it to return 0.

This commit fixes the issue by using a regular expression to extract the first valid number from the string. This ensures that inputs like '1.2.3' or '5-5' are parsed correctly.

Additionally, the function now handles thousand separators by stripping commas before parsing.